### PR TITLE
feat: update Memos API structure to support new version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bin/
 .cursor/
 local.yaml
 test.sh
+.vscode/

--- a/internal/social/memos_test.go
+++ b/internal/social/memos_test.go
@@ -21,7 +21,7 @@ func TestMemos_ListMemos_Localhost(t *testing.T) {
 
 	memos := NewMemos(endpoint, token, "memos")
 
-	response, err := memos.ListMemos(context.Background(), nil)
+	response, err := memos.ListPosts(context.Background(), 10)
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
@@ -31,10 +31,10 @@ func TestMemos_ListMemos_Localhost(t *testing.T) {
 		return
 	}
 
-	t.Logf("Successfully retrieved %d memos", len(response.Memos))
+	t.Logf("Successfully retrieved %d memos", len(response))
 
-	for _, memo := range response.Memos {
-		t.Logf("Memo: %+v, %+v, %+v", memo.Name, memo.CreateTime, len(memo.Resources))
+	for _, memo := range response{
+		t.Logf("Memo: %+v, %+v, %+v", memo.ID, memo.CreatedAt, len(memo.Media))
 	}
 
 	posts, err := memos.ListPosts(context.Background(), 10)


### PR DESCRIPTION
- Update Memo struct to match new API response format
- Replace 'rowStatus' with 'state' field (NORMAL/ARCHIVED)
- Replace 'resources' with 'attachments' field
- Add new fields: nodes, tags, property, snippet
- Add support structs: Attachment, Node, ParagraphNode, TextNode, Property
- Maintain backward compatibility with deprecated fields (uid, rowStatus, resources)
- Update ListPosts method to handle both new and old API formats
- Prioritize new 'attachments' field, fallback to 'resources' for compatibility